### PR TITLE
fixed: 컬럼 길이 오류 해결: products.code 및 inspections.product_code 길이를 36으로 조정

### DIFF
--- a/src/main/java/org/pro/netandback/domain/product/model/entity/Product.java
+++ b/src/main/java/org/pro/netandback/domain/product/model/entity/Product.java
@@ -19,7 +19,7 @@ public class Product extends BaseTime {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "code", length = 20, nullable = false, updatable = false)
+	@Column(name = "code", length = 36, nullable = false, updatable = false)
 	private String code;
 
 	@Column(name = "name", length = 100, nullable = false)


### PR DESCRIPTION
hibernate 업데이트시에 DB는 36인데 엔티티값은 20으로 계속 변경하려고 해서 오류가 나서 DB값으로 일치시켰습니다.